### PR TITLE
Allow duplicate non-sibling Markdown headings

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -7,3 +7,7 @@ extends: null
 # line-length
 # Let Prettier handle formatting
 MD013: false
+
+# no-duplicate-heading
+MD024:
+  siblings_only: true


### PR DESCRIPTION
By default, `markdownlint` prohibits headings from being repeated in a document. However, it can be useful to have the same subheading under multiple higher-level headings. I have changed the configuration to allow duplicate headings if they do not share the same parent.