### PR TITLE
Do not exclude `setuptools` from `pip freeze`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ export PYTHONPATH := $(shell realpath .)
 
 .PHONY: reqs-freeze
 reqs-freeze:
+	# Complex logic needed to pin `setuptools` but not `pip` in Python 3.11 and earlier
+	PYTHON_VERSION_AT_LEAST_3_12=$(shell python -c 'import sys; print(int(sys.version_info >= (3, 12)))')
+ifeq ($(PYTHON_VERSION_AT_LEAST_3_12),1)
 	pip freeze >requirements-lock.txt
+else
+	pip freeze --all --exclude pip >requirements-lock.txt
+endif
 	# Strip local versions so PyTorch is the same on Linux and macOS
 	sed --in-place -e 's/+[[:alnum:]]\+$$//g' requirements-lock.txt
 	# Remove DeepSpeed because it cannot be installed automatically


### PR DESCRIPTION
`pip freeze` has special logic to not output `distribute`, `setuptools`, or `wheel` unless using Python 3.12 or higher. I created this repository assuming the use of Python 3.12, so I did not encounter this problem until using these files with Python 3.11. Because the code for older Python versions is not ideal, I have set it to be conditional on the version.

This code should be dropped in either 2025 Q4 (when the Scientific Python ecosystem drops support for Python 3.11)[^1] or in 2027-10 (when Python 3.11 reaches EOL).[^2]

[^1]: https://scientific-python.org/specs/spec-0000//#drop-schedule
[^2]: https://devguide.python.org/versions/