### PR TITLE
Enable `pyupgrade` rules in `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ select = [
   "E", # pycodestyle error
   "F", # pyflakes
   "I", # isort
+  "UP", # pyupgrade
   "W", # pycodestyle warning
 ]
 


### PR DESCRIPTION
In a private repo, I noticed many imports from `typing` that were no longer needed, so I thought it would be a good idea to have them automatically replaced. This set of rules should help move us to newer Python features.