### PR TITLE
Save `deepspeed` version to `requirements-lock.txt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ else
 endif
 	# Strip local versions so PyTorch is the same on Linux and macOS
 	sed --in-place -e 's/+[[:alnum:]]\+$$//g' requirements-lock.txt
-	# Remove DeepSpeed because it cannot be installed automatically
-	sed --in-place -e '/^deepspeed==.*/d' requirements-lock.txt
 	# Remove nvidia-* and triton because they cannot be installed on macOS
 	# The packages have no sdists, and their wheels are not available for macOS
 	# They install automatically on Linux as a requirement of PyTorch


### PR DESCRIPTION
The package is difficult enough to install that we should use a consistent version. The manual installation process is complicated enough that the extra parameter to overwrite the version installed by `make update` is inconsequential.