### PR TITLE
Enable `flake8-bugbear` checks for `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ line-length = 100
 [tool.ruff.lint]
 ignore-init-module-imports = true
 select = [
+  "B", # flake8-bugbear
   "D", # pydocstyle
   "E", # pycodestyle error
   "F", # pyflakes


### PR DESCRIPTION
I have used the original package in other repositories before, so I have enabled the analogous rules in `ruff`.