### PR TITLE
Ignore more files created by Python tooling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,13 @@ node_modules/
 *.py[cod]
 __pycache__/
 # Code quality tooling files
+.coverage
+.coverage.*
 .mypy_cache/
+.nox/
 .ruff_cache/
+.tox/
+htmlcov/
 # Distribution / packaging files
 *.egg-info/
 # Jupyter notebook files


### PR DESCRIPTION
I encountered a project using `coverage`, so I copied some more Python tooling entries from the upstream `.gitignore` file.