### PR TITLE
Enable `flake8-use-pathlib` checks for `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,14 @@ select = [
   "E", # pycodestyle error
   "F", # pyflakes
   "I", # isort
+  "PTH", # flake8-use-pathlib
   "UP", # pyupgrade
   "W", # pycodestyle warning
+]
+ignore = [
+  # Do not switch to `Path.open()` because `open()` is easier to test with
+  # e.g., `open(data_dir / "file_a.txt")` -> `open("test/file_b.txt")`
+  "PTH123", # builtin-open (from flake8-use-pathlib)
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
I tested this out on several repositories. It would be annoying to apply to a large existing codebase, but it's definitely useful for smaller ones.

Please let me know what you think of not using [`PTH123`](https://docs.astral.sh/ruff/rules/builtin-open/). This is a personal preference of mine, but I know some others don't agree.