### PR TITLE
Disable redundant `pylint` rule `consider-using-f-string`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ allow-reexport-from-package = true
 [tool.pylint.messages_control]
 # Most of these are disabled to prevent issues with dependencies being difficult to inspect
 # pylint FAQ recommends disabling:
-# wrong-import-order when using isort
-# missing-module-docstring,missing-class-docstring,missing-function-docstring when using pydocstyle
+# - `wrong-import-order` when using `isort`
+# - `missing-module-docstring`, `missing-class-docstring`,
+#   `missing-function-docstring` when using `pydocstyle`
+# Disabled `consider-using-f-string` because handled by `pyupgrade`
 disable = """
 R,fixme,no-member,unsupported-membership-test,unsubscriptable-object,
 unsupported-assignment-operation,not-an-iterable,too-many-lines,wrong-import-order,
-missing-module-docstring,missing-class-docstring,missing-function-docstring
+missing-module-docstring,missing-class-docstring,missing-function-docstring,
+consider-using-f-string
 """
 
 [tool.pylint.reports]


### PR DESCRIPTION
While documenting this redundancy directly in the `pyproject.toml` file, I took the time to reorganize this comment section to be more readable. We will likely be adding more rules to ignore as `ruff` improves.