### PR TITLE
Disable ShellCheck rules that fail for missing files

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,19 @@
-enable=add-default-case # https://github.com/koalaman/shellcheck/wiki/SC2249
-enable=avoid-nullary-conditions # https://github.com/koalaman/shellcheck/wiki/SC2244
-enable=require-double-brackets # https://github.com/koalaman/shellcheck/wiki/SC2292
-disable=SC1090 # "Can't follow non-constant source. Use a directive to specify location"; https://www.shellcheck.net/wiki/SC1090
-disable=SC1091 # "Not following: (error message here)"; https://www.shellcheck.net/wiki/SC1091
+# "Consider adding a default `*)` case, even if it just exits with error."
+# https://www.shellcheck.net/wiki/SC2249
+enable=add-default-case
+
+# "Prefer explicit `-n` to check non-empty string (or use `=`/`-ne` to check boolean/integer)."
+# https://www.shellcheck.net/wiki/SC2244
+enable=avoid-nullary-conditions
+
+# "Prefer `[[ ]]` over `[ ]` for tests in Bash/Ksh."
+# https://www.shellcheck.net/wiki/SC2292
+enable=require-double-brackets
+
+# "Can't follow non-constant source. Use a directive to specify location"
+# https://www.shellcheck.net/wiki/SC1090
+disable=SC1090
+
+# "Not following: (error message here)"
+# https://www.shellcheck.net/wiki/SC1091
+disable=SC1091

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,5 @@
 enable=add-default-case # https://github.com/koalaman/shellcheck/wiki/SC2249
 enable=avoid-nullary-conditions # https://github.com/koalaman/shellcheck/wiki/SC2244
 enable=require-double-brackets # https://github.com/koalaman/shellcheck/wiki/SC2292
+disable=SC1090 # "Can't follow non-constant source. Use a directive to specify location"; https://www.shellcheck.net/wiki/SC1090
+disable=SC1091 # "Not following: (error message here)"; https://www.shellcheck.net/wiki/SC1091


### PR DESCRIPTION
Our scripts often contain references to files outside of our repositories, so we should not error every time a file is missing.

I also improved the file's organization while I was modifying it.