### PR TITLE
Add `texthooks` checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,14 @@ repos:
       - id: no-commit-to-branch
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/sirosen/texthooks
+    rev: 0.6.6
+    hooks:
+      - id: alphabetize-codeowners
+      - id: fix-ligatures
+      - id: fix-smartquotes
+      - id: fix-spaces
+      - id: forbid-bidi-controls
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:


### PR DESCRIPTION
Most of these handle characters that should not belong in the average file but are accidentally included by copying and pasting: ligatures, smart quotes, and non-breaking spaces.

I also enabled the `CODEOWNERS`-related check because I plan to add a `CODEOWNERS` file to this repository in the future.

---

I tried these out in a private repo, and the `fix-spaces` hook was incredibly useful!