### PR TITLE
Overhaul `yamllint` configuration

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,2 @@
 printWidth: 100
-proseWrap: "never"
+proseWrap: never

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -26,3 +26,10 @@ rules:
   # further configuration is needed.
   quoted-strings:
     required: only-when-needed
+  truthy:
+    # YAML keys are parsed as booleans the same way as values, so they are checked by default
+    # GitHub Actions uses the key `on`, which is considered a boolean in YAML v1.1 but not YAML v1.2
+    # Therefore, it is likely that GitHub Actions uses YAML v1.2 so this will not be a problem
+    # Outside of GitHub Actions, there is little use for `on`, `off`, `yes`, and `no` (and capitalization variants)
+    # as keys, so this check is mostly superfluous
+    check-keys: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,17 +1,19 @@
 extends: default
 
 rules:
-  colons: disable # Let Prettier handle formatting
-  commas: disable # Let Prettier handle formatting
+  # Let Prettier handle most formatting
+  colons: disable
+  commas: disable
   comments:
     min-spaces-from-content: 1 # Match Prettier formatting
-  document-start: disable
-  empty-lines: disable # Let Prettier handle formatting
-  empty-values: enable
-  indentation: disable # Let Prettier handle formatting
-  hyphens: disable # Let Prettier handle formatting
-  line-length: disable # Let Prettier handle formatting
-  new-line-at-end-of-file: disable # Let Prettier handle formatting
+  empty-lines: disable
+  hyphens: disable
+  indentation: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
   new-lines: disable # Let end-of-file-fixer handle formatting
+  trailing-spaces: enable
+
+  document-start: disable
+  empty-values: enable
   octal-values: enable
-  trailing-spaces: enable # Let trailing-whitespace handle formatting

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -17,3 +17,9 @@ rules:
   document-start: disable
   empty-values: enable
   octal-values: enable
+  # yamllint assumes that values like `01:23` are strings, not base-60 numbers.
+  # This is correct for YAML v1.2 but not YAML v1.1.
+  # When using literals of this form that should be treated as strings,
+  # further configuration is needed.
+  quoted-strings:
+    required: only-when-needed

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -15,7 +15,10 @@ rules:
   trailing-spaces: enable
 
   document-start: disable
-  empty-values: enable
+  empty-values:
+    # YAML keys with empty values are common, so allow them
+    # This still forbids keys with empty values in embedded JSON-like objects
+    forbid-in-block-mappings: false
   octal-values: enable
   # yamllint assumes that values like `01:23` are strings, not base-60 numbers.
   # This is correct for YAML v1.2 but not YAML v1.1.

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -19,7 +19,10 @@ rules:
     # YAML keys with empty values are common, so allow them
     # This still forbids keys with empty values in embedded JSON-like objects
     forbid-in-block-mappings: false
-  octal-values: enable
+  # Allow `0o755` but not `0755`
+  # Octal values are sometimes used for expressing permissions, so they should not be prohibited
+  octal-values:
+    forbid-explicit-octal: false
   # yamllint assumes that values like `01:23` are strings, not base-60 numbers.
   # This is correct for YAML v1.2 but not YAML v1.1.
   # When using literals of this form that should be treated as strings,


### PR DESCRIPTION
I made a variety of changes to improve our YAML linting by both increasing strictness in some regards and reducing strictness in others. They were developed with and tested on various files I have locally, including a basic GitHub Actions workflow. I put my rationale as inline comments instead of in commit messages because they are useful to see once copied over to another repository.

Some of these changes are highly opinionated, so feel free to veto or adjust them as needed.