### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,49 @@
+name: Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - test-ci**
+  workflow_dispatch: # Enable workflow to be run manually
+
+# Cancel the currently running CI job if you push a change while CI is running
+# Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-22.04
+    name: Run checks
+    env:
+      PYTHON_VERSION: 3.12.3
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: requirements-lock.txt
+      - name: Install dependencies into Python environment
+        run: |
+          make update
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: precommit--${{ runner.os }}--${{ runner.arch }}--${{ env.PYTHON_VERSION }}--${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run all checks
+        run: |
+          make check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,10 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ endif
 	# They install automatically on Linux as a requirement of PyTorch
 	sed --in-place -e '/^\(nvidia-.*\|triton\)==.*/d' requirements-lock.txt
 
+.PHONY: actionlint
+actionlint:
+	pre-commit run --all-files actionlint
+
 .PHONY: black
 black:
 	pre-commit run --all-files black

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This project uses various code quality tooling, all of which is automatically in
 
 All checks can be run with `make check`, and some additional automatic changes can be run with `make fix`.
 
+To test GitHub Actions workflows locally, install [`act`](https://github.com/nektos/act) and run it with `act`.
+
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
This will run all checks contained in this repository on itself.

I have tested this branch with both `act` and GitHub Actions. I'd like to note two important differences I found between the services:

* `act` caches the installed Python environment but GitHub Actions only caches the `pip` cache
* `actionlint` runs `shellcheck` on embedded scripts if `shellcheck` is in `PATH`, which is the case on GitHub Actions runners but not the default `act` runner