### PR TITLE
Disable `no-commit-to-branch` in GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -46,4 +46,4 @@ jobs:
           key: precommit--${{ runner.os }}--${{ runner.arch }}--${{ env.PYTHON_VERSION }}--${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run all checks
         run: |
-          make check
+          SKIP=no-commit-to-branch make check


### PR DESCRIPTION
We are usually merging to protected branches when running GHA, so it should be disabled. Otherwise, checks will always fail on the default branch.