### PR TITLE
Add `.pytest_cache/` to `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__/
 .coverage.*
 .mypy_cache/
 .nox/
+.pytest_cache/
 .ruff_cache/
 .tox/
 htmlcov/


### PR DESCRIPTION
I discovered this was needed in a repository that uses `pytest`.