### PR TITLE
Improve `markdownlint` configuration

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,12 +1,9 @@
 # Default state for all rules
 default: true
 
-# Path to configuration file to extend
-extends: null
-
-# line-length
-# Let Prettier handle formatting
-MD013: false
+# Disable rules that conflict with Prettier
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Prettier.md
+extends: markdownlint/style/prettier
 
 # no-duplicate-heading
 MD024:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,10 +1,11 @@
-# Default state for all rules
+# Enable all rules
 default: true
 
 # Disable rules that conflict with Prettier
 # See https://github.com/DavidAnson/markdownlint/blob/main/doc/Prettier.md
 extends: markdownlint/style/prettier
 
-# no-duplicate-heading
-MD024:
+# Allow duplicate headings if they are not siblings
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
+no-duplicate-heading:
   siblings_only: true


### PR DESCRIPTION
I disabled `markdownlint` rules that conflict with `prettier` and made miscellaneous improvements to `.markdownlint.yaml`.