### PR TITLE
Show fixes that `ruff` applies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ warn_unreachable = true
 [tool.ruff]
 fix = true
 line-length = 100
+show-fixes = true
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
It's easier to review automatic changes made by `ruff` if it tells us what it has changed.