### PR TITLE
Improve `codespell` comment for maintainability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ line-length = 100
 
 [tool.codespell]
 ignore-regex = "\\[nt]" # Do not count escaped newlines or tabs as part of a word
-ignore-words-list = "astroid" # Dependency of pylint
+# `astroid` is a dependency of pylint
+ignore-words-list = "astroid"
 quiet-level = 0 # Display all warnings
 check-filenames = ""
 check-hidden = ""


### PR DESCRIPTION
We can now simply add a comment on a new line whenever another entry is added to the `ignore-words-list` option.