### PR TITLE
Enable `check-shebang-scripts-are-executable`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
       - id: check-symlinks
       - id: check-toml
       - id: check-vcs-permalinks


### PR DESCRIPTION
We already have `check-executables-have-shebangs` enabled, so we should enable the converse rule. This will ensure that a file is executable iff it has a shebang.