### PR TITLE
Use maintained fork of official `prettier` mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,10 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier # Use maintained fork of official mirror
+    rev: v3.3.2
     hooks:
       - id: prettier
-        additional_dependencies:
-          - prettier@3.3.2
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.8.0-1
     hooks:


### PR DESCRIPTION
The official `prettier` pre-commit hook[^1] was archived back in April, citing that "prettier made some changes that breaks plugins entirely".[^2] Although another official hook might be created at some point, this fork is good enough for now.

It has the extra benefit that it properly handles new `prettier` releases, so we don't need to manually update `additional_dependencies` anymore.

[^1]: https://github.com/pre-commit/mirrors-prettier
[^2]: https://github.com/pre-commit/mirrors-prettier/commit/f62a70a3a7114896b062de517d72829ea1c884b6