### PR TITLE
Add GitHub branch protection rules

### DIFF
--- a/.github/protect_default_branch.json
+++ b/.github/protect_default_branch.json
@@ -1,0 +1,41 @@
+{
+  "name": "Protect branch",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": []
+      }
+    },
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
I exported the branch protection ruleset configured for this repository and manually removed fields from the JSON that were specific to this repository. Because GHA workflows are repository-specific, they need to be manually configured when adding these rules to a repository.