### PR TITLE
Add `lychee` (a link checker) to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,9 @@ repos:
         additional_dependencies:
           # `tomllib` was added to stdlib in Python 3.11
           - tomli==2.0.1 ; python_version < "3.11"
+  - repo: https://github.com/lycheeverse/lychee
+    rev: v0.15.1
+    hooks:
+      - id: lychee
+        # Only run manually because it can have false positives and spurious failures
+        stages: [manual]

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ black:
 codespell:
 	pre-commit run --all-files codespell
 
+.PHONY: lychee
+lychee:
+	pre-commit run --all-files --hook-stage manual lychee
+
 .PHONY: markdownlint
 markdownlint:
 	pre-commit run --all-files markdownlint


### PR DESCRIPTION
I set it to only run manually because we can get various false-positives, but it's a useful tool to run occasionally.

I have tested this commit in another repository without any problems, so I feel comfortable upstreaming it to this repository.