### PR TITLE
Restrict GitHub API access from GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,6 +10,11 @@ on:
       - test-ci**
   workflow_dispatch: # Enable workflow to be run manually
 
+# Disable all access to the GitHub API by default
+# This default can be overridden for individual workflows and jobs
+# Documentation: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+permissions: {}
+
 # Cancel the currently running CI job if you push a change while CI is running
 # Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:


### PR DESCRIPTION
The workflow now provides a secure default that can be overridden as needed.