### PR TITLE
Disable `pylint` warnings covered by `flake8-logging-format`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,13 +106,17 @@ allow-reexport-from-package = true
 # - `missing-module-docstring`, `missing-class-docstring`,
 #   `missing-function-docstring` when using `pydocstyle`
 # Disabled `consider-using-f-string` because handled by `pyupgrade`
-# Disabled `logging-not-lazy` because handled by `flake8-logging-format`
+# Disabled because handled by `flake8-logging-format`:
+# - `logging-format-interpolation`
+# - `logging-fstring-interpolation`
+# - `logging-not-lazy`
 # Disabled `broad-exception-caught` because handled by `flake8-blind-except`
 disable = """
 R,fixme,no-member,unsupported-membership-test,unsubscriptable-object,
 unsupported-assignment-operation,not-an-iterable,too-many-lines,wrong-import-order,
 missing-module-docstring,missing-class-docstring,missing-function-docstring,
-consider-using-f-string,logging-not-lazy,broad-exception-caught
+consider-using-f-string,logging-format-interpolation,logging-fstring-interpolation,logging-not-lazy,
+broad-exception-caught
 """
 
 [tool.pylint.reports]


### PR DESCRIPTION
These checks are all redundant.