### PR TITLE
Run `mypy` and `pylint` with `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         additional_dependencies:
           # `tomllib` was added to stdlib in Python 3.11
           - tomli==2.2.1 ; python_version < "3.11"
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        language: system
+        entry: mypy
+        types:
+          - python
+        require_serial: true
+      - id: pylint
+        name: pylint
+        language: system
+        entry: pylint
+        types:
+          - python
+        require_serial: true
   - repo: https://github.com/lycheeverse/lychee
     rev: lychee-v0.18.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ default:
 
 SHELL=/usr/bin/env bash
 
-PYTHON_FILES=$(shell git ls-files '*.py' | sort | tr '\n' ' ')
-
 export PYTHONPATH := $(shell realpath .)
 
 .PHONY: lock
@@ -48,9 +46,7 @@ markdownlint:
 
 .PHONY: mypy
 mypy:
-ifneq ($(PYTHON_FILES),)
-	mypy $(PYTHON_FILES)
-endif
+	pre-commit run --all-files mypy
 
 .PHONY: prettier
 prettier:
@@ -58,9 +54,7 @@ prettier:
 
 .PHONY: pylint
 pylint:
-ifneq ($(PYTHON_FILES),)
-	pylint $(PYTHON_FILES)
-endif
+	pre-commit run --all-files pylint
 
 .PHONY: ruff
 ruff:
@@ -83,7 +77,7 @@ precommit:
 	pre-commit run --all-files
 
 .PHONY: check
-check: precommit mypy pylint
+check: precommit
 
 .PHONY: fix
 fix: lock check


### PR DESCRIPTION
This simplifies both the `Makefile` logic and the check output.

---

I ran this in a repository that actually has Python files to confirm it works.