### PR TITLE
Update GitHub branch protection rules

### DIFF
--- a/.github/protect_default_branch.json
+++ b/.github/protect_default_branch.json
@@ -23,13 +23,16 @@
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": false
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["merge"]
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
         "required_status_checks": []
       }
     },


### PR DESCRIPTION
I re-exported the ruleset after adjusting the settings for some new features that were recently rolled out.