### PR TITLE
Disable `ruff` check `G004` (`logging-f-string`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,18 @@ select = [
   "YTT", # flake8-2020
 ]
 ignore = [
+  # Do not prohibit f-strings in logging messages
+  # The documentation describes two motivations, but I (@aphedges) disagree with both:
+  # - Using f-strings means that string formatting is carried out eagerly, but
+  #   f-string formatting takes such a short time that optimizing it away isn't worth it.
+  # - Passing in arguments means that they can be used by other logging handlers
+  #   (e.g., structured logging), but our logging is *significantly* simpler than that.
+  # In addition, I personally was avoiding using f-strings for logging because of documented
+  # security concerns, but at the time of writing, I was unable to find an exploit that would
+  # actually affect us. Finally, the native formatting used by the `logging` module is ancient,
+  # so it cannot express some formats that f-strings can. In all, I believe that enforcing the use
+  # of the `logging` module's default formatter is not worth the inconveniences it causes.
+  "G004", # logging-f-string (from flake8-logging-format)
   # Do not switch to `Path.open()` because `open()` is easier to test with
   # e.g., `open(data_dir / "file_a.txt")` -> `open("test/file_b.txt")`
   "PTH123", # builtin-open (from flake8-use-pathlib)


### PR DESCRIPTION
I realized this check was failing after already writing many logging statements in a private repository, and it was not worth the effort to fix given the questionable nature of this check in the first place.

---

I forgot to upstream this patch from the private repository back in October...