### PR TITLE
Use `$(MAKE)` instead of `make` in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ upgrade:
 
 .PHONY: install
 install:
-	make update
+	$(MAKE) update


### PR DESCRIPTION
According to the GNU make documentation:[^1]

> Recursive `make` commands should always use the variable `MAKE`, not
> the explicit command name '`make`'

[^1]: https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html