### PR TITLE
Require minimum version of `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 #   pre-commit run --all-files
 # Update this file:
 #   pre-commit autoupdate
+minimum_pre_commit_version: 1.15.0
 default_language_version:
   # Use latest LTS release
   node: 22.13.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 mypy[faster-cache]>=1.13
-pre-commit
+# `pre-commit` `1.15.0` introduced `minimum_pre_commit_version` top-level key
+pre-commit>=1.15.0
 pylint


### PR DESCRIPTION
`pre-commit` `1.15.0` is the earliest version to support `minimum_pre_commit_version`, which helps require a minimum version. It is somewhat cyclical to require a version only to support requiring a version, but a slightly earlier version, `1.14.0`, introduced `default_language_version`, which we use and therefore should require.