### PR TITLE
Improve dependencies, including switching to dependency groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,10 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: https://github.com/pypa/dependency-groups
+    rev: 1.3.1
+    hooks:
+      - id: lint-dependency-groups
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ update:
 .PHONY: upgrade
 upgrade:
 	pip install --upgrade pip
-	pip install --upgrade --upgrade-strategy eager -r requirements.txt -r requirements-dev.txt
+	pip install --upgrade --upgrade-strategy eager --group base --group dev
 
 .PHONY: install
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 ]
 
 [project]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 [tool.black]
 line-length = 100
@@ -27,7 +27,7 @@ check-hidden = ""
 [tool.mypy]
 show_error_codes = true
 ignore_missing_imports = true
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_unreachable = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [dependency-groups]
 base = []
 dev = [
+  # `mypy` `1.13.0` introduced `faster-cache` extra
   "mypy[faster-cache]>=1.13",
   # `pre-commit` `1.15.0` introduced `minimum_pre_commit_version` top-level key
   "pre-commit>=1.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[dependency-groups]
+base = []
+dev = [
+  "mypy[faster-cache]>=1.13",
+  # `pre-commit` `1.15.0` introduced `minimum_pre_commit_version` top-level key
+  "pre-commit>=1.15.0",
+  "pylint",
+]
+
 [project]
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ dev = [
   "mypy[faster-cache]>=1.13",
   # `pre-commit` `1.15.0` introduced `minimum_pre_commit_version` top-level key
   "pre-commit>=1.15.0",
-  "pylint",
+  # Set a minimum version (released 2023-10-02, first to support `3.12`)
+  # to prevent possible resolution problems
+  "pylint>=3",
 ]
 
 [project]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-mypy[faster-cache]>=1.13
-# `pre-commit` `1.15.0` introduced `minimum_pre_commit_version` top-level key
-pre-commit>=1.15.0
-pylint


### PR DESCRIPTION
This PR transitions to using dependency groups, improves our dev dependencies, and bumps the expected Python version to 3.12.