### PR TITLE
Add `*.ipynb` files to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 [*.md]
 max_line_length = off
 
-[*.py]
+[*.{ipynb,py}]
 indent_size = 4
 
 # Makefiles always use tabs for indentation


### PR DESCRIPTION
Python notebooks should use the same indentation as Python files.

I made this change on a private repository, and I've cherry-picked the commit here.