### PR TITLE
Replace `black` with `ruff-format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,11 +50,6 @@ repos:
       - id: fix-spaces
       - id: fix-unicode-dashes
       - id: forbid-bidi-controls
-  # Use mirror for `mypyc`-compiled `black`
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
-    hooks:
-      - id: black
   - repo: https://github.com/rbubley/mirrors-prettier # Use maintained fork of official mirror
     rev: v3.6.2
     hooks:
@@ -71,6 +66,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.5
     hooks:
+      - id: ruff-format
+        args: [--exit-non-zero-on-fix]
       - id: ruff-check
         args: [--exit-non-zero-on-fix]
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ endif
 actionlint:
 	pre-commit run --all-files actionlint
 
-.PHONY: black
-black:
-	pre-commit run --all-files black
-
 .PHONY: codespell
 codespell:
 	pre-commit run --all-files codespell
@@ -59,6 +55,10 @@ pylint:
 .PHONY: ruff
 ruff:
 	pre-commit run --all-files ruff-check
+
+.PHONY: ruff-format
+ruff-format:
+	pre-commit run --all-files ruff-format
 
 .PHONY: shellcheck
 shellcheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,6 @@ dev = [
 [project]
 requires-python = ">=3.12"
 
-[tool.black]
-line-length = 100
-
 [tool.codespell]
 ignore-regex = "\\[nt]" # Do not count escaped newlines or tabs as part of a word
 # `astroid` is a dependency of pylint


### PR DESCRIPTION
The latter has been available for a while, and I feel comfortable switching to it now. It also means that we can now drop a dependency from our checks!

I tested this out on one private repository, and all changes were good/expected.